### PR TITLE
Change calendar logo link

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,7 +15,7 @@
 <body>
     <nav class="navbar navbar-expand-lg bg-transparent">
         <div class="container-fluid">
-            <a class="navbar-brand" href="#">Calendar</a>
+            <a class="navbar-brand" href="/">Calendar</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText"
                 aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Change calendar link from '#' to '/' to get the home page
when clicking on the logo